### PR TITLE
🚧 Add support for SoundCloud downloads

### DIFF
--- a/vvd-downloader/README.md
+++ b/vvd-downloader/README.md
@@ -29,6 +29,7 @@ Currently, VocaDB Video Downloader only supports:
 | Niconico      | youtube-dl or its fork, [nndownload](https://github.com/AlexAplin/nndownload)      |
 | YouTube       | youtube-dl or its fork     |
 | Bilibili      | youtube-dl or its fork     |
+| SoundCloud    | youtube-dl or its fork     |
 
 So pretty much by setting up one of the youtube-dl distributions, you are good to go.
 
@@ -61,8 +62,8 @@ config: # configuration
     # the downloader will use this list as an order of which pv service to check first
     # you can also disable one or more PV services by not listing them
     # values here are comma separated, the value must be same as the pv service string in VocaDB APIs Swagger Page at https://vocadb.net/swagger/ui/index
-    # but currently we only support NicoNicoDouga, Youtube and Bilibili
-    pv-preference: NicoNicoDouga, Youtube, Bilibili
+    # but currently we only support NicoNicoDouga, Youtube, Bilibili and SoundCloud
+    pv-preference: NicoNicoDouga, Youtube, Bilibili, SoundCloud
     # maximum retry before calling it a failure
     # this does not include the first try. For example, 2 means a maximum of 3 tries can be performed
     max-retry-count: 2
@@ -85,11 +86,13 @@ config: # configuration
   # (note for dev): when new PV service is added, change it on DownloaderBaseConfig
   enablement:
     # currently support youtube-dl and nndownload
-    NicoNicoDouga: 
+    NicoNicoDouga:
     # currently only support youtube-dl
-    Youtube: 
+    Youtube:
     # currently only support youtube-dl
     Bilibili:
+    # currently only support youtube-dl
+    SoundCloud:
 
   # which field is required or optional depends on if the pv service is listed in config.preference.pv-preference field also if the downloader is enabled in the config.enablement field
   downloader:
@@ -125,6 +128,12 @@ config: # configuration
         launch-cmd:
         external-args:
 
+    # same way of configuring NicoNicoDouga
+    SoundCloud:
+      youtube-dl:
+        launch-cmd:
+        external-args:
+
   # all fields are requried
   environment:
     # path of the mediainfo cli tool
@@ -132,7 +141,7 @@ config: # configuration
     # or if the cli tool is already in your PATH, you can leave this as "mediainfo"
     # for debian based distros, you can install mediainfo using "sudo apt-get install mediainfo"
     mediainfo-launch-cmd:
-  
+
   # all fields are required
   download:
     # these two fields control the timeout of the downloading. If the download is not finished within the timeout, the download will be considered as failed.

--- a/vvd-downloader/src/main/kotlin/mikufan/cx/vvd/downloader/component/downloader/implementation/SoundCloudYtDlDownloader.kt
+++ b/vvd-downloader/src/main/kotlin/mikufan/cx/vvd/downloader/component/downloader/implementation/SoundCloudYtDlDownloader.kt
@@ -1,0 +1,30 @@
+package mikufan.cx.vvd.downloader.component.downloader.implementation
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import mikufan.cx.vvd.commonkt.vocadb.PVServicesEnum
+import mikufan.cx.vvd.downloader.component.downloader.base.BaseYtDlDownloader
+import mikufan.cx.vvd.downloader.config.DownloadConfig
+import mikufan.cx.vvd.downloader.config.EnvironmentConfig
+import mikufan.cx.vvd.downloader.config.downloader.SC_YTDL
+import mikufan.cx.vvd.downloader.config.downloader.SoundCloudYtDlCondition
+import mikufan.cx.vvd.downloader.config.downloader.SoundCloudYtDlConfig
+import org.apache.tika.Tika
+import org.springframework.context.annotation.Conditional
+import org.springframework.stereotype.Component
+
+@Component
+@Conditional(SoundCloudYtDlCondition::class)
+class SoundCloudYtDlDownloader(
+  config: SoundCloudYtDlConfig,
+  downloadConfig: DownloadConfig,
+  tika: Tika,
+  environmentConfig: EnvironmentConfig,
+  objectMapper: ObjectMapper,
+) : BaseYtDlDownloader(
+  downloadConfig, tika, environmentConfig, objectMapper
+) {
+  override val downloaderName: String = "$SC_YTDL or its forks"
+  override val targetPvService: PVServicesEnum = PVServicesEnum.SOUNDCLOUD
+  override val launchCmd: List<String> = config.launchCmd
+  override val externalArgs: List<String> = config.externalArgs
+}

--- a/vvd-downloader/src/main/kotlin/mikufan/cx/vvd/downloader/config/downloader/SoundCloudConditions.kt
+++ b/vvd-downloader/src/main/kotlin/mikufan/cx/vvd/downloader/config/downloader/SoundCloudConditions.kt
@@ -1,0 +1,11 @@
+package mikufan.cx.vvd.downloader.config.downloader
+
+import mikufan.cx.vvd.commonkt.vocadb.PVServicesEnum
+
+abstract class SoundCloudBaseDownloaderCondition : DownloaderBaseCondition {
+  override val pvServices = PVServicesEnum.SOUNDCLOUD
+}
+
+class SoundCloudYtDlCondition : SoundCloudBaseDownloaderCondition() {
+  override val downloaderName: String = SC_YTDL
+}

--- a/vvd-downloader/src/main/kotlin/mikufan/cx/vvd/downloader/config/downloader/SoundCloudConfigs.kt
+++ b/vvd-downloader/src/main/kotlin/mikufan/cx/vvd/downloader/config/downloader/SoundCloudConfigs.kt
@@ -1,0 +1,16 @@
+package mikufan.cx.vvd.downloader.config.downloader
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Conditional
+import org.springframework.validation.annotation.Validated
+
+@ConfigurationProperties("$SC_CONFIG_PROP_KEY.$SC_YTDL")
+@Validated
+@Conditional(SoundCloudYtDlCondition::class)
+data class SoundCloudYtDlConfig(
+  @field:NotEmpty
+  override val launchCmd: List<@NotBlank String>,
+  val externalArgs: List<@NotBlank String>,
+) : DownloaderBaseConfig

--- a/vvd-downloader/src/main/kotlin/mikufan/cx/vvd/downloader/config/downloader/SoundCloudConstants.kt
+++ b/vvd-downloader/src/main/kotlin/mikufan/cx/vvd/downloader/config/downloader/SoundCloudConstants.kt
@@ -1,0 +1,4 @@
+package mikufan.cx.vvd.downloader.config.downloader
+
+const val SC_CONFIG_PROP_KEY = "config.downloader.sound-cloud"
+const val SC_YTDL = "youtube-dl"

--- a/vvd-downloader/src/main/kotlin/mikufan/cx/vvd/downloader/config/preference/SupportedPvServiceValidation.kt
+++ b/vvd-downloader/src/main/kotlin/mikufan/cx/vvd/downloader/config/preference/SupportedPvServiceValidation.kt
@@ -20,6 +20,7 @@ val SUPPORTED_SERVICES: Set<PVServicesEnum> = setOf(
   NICONICODOUGA,
   YOUTUBE,
   BILIBILI,
+  SOUNDCLOUD,
 )
 
 /**

--- a/vvd-downloader/src/main/resources/application.yml
+++ b/vvd-downloader/src/main/resources/application.yml
@@ -19,7 +19,7 @@ config: # configuration
     # you can also disable one or more PV services by not listing them
     # values here are comma separated, the value must be same as the pv service string in VocaDB APIs Swagger Page at https://vocadb.net/swagger/ui/index
     # but currently we only support NicoNicoDouga, Youtube, Bilibili and SoundCloud
-    pv-preference: NicoNicoDouga, SoundCloud, Youtube, Bilibili
+    pv-preference: NicoNicoDouga, Youtube, Bilibili, SoundCloud
     # maximum retry before calling it a failure
     # this does not include the first try. For example, 2 means a maximum of 3 tries can be performed
     max-retry-count: 2

--- a/vvd-downloader/src/main/resources/application.yml
+++ b/vvd-downloader/src/main/resources/application.yml
@@ -18,8 +18,8 @@ config: # configuration
     # the downloader will use this list as an order of which pv service to check first
     # you can also disable one or more PV services by not listing them
     # values here are comma separated, the value must be same as the pv service string in VocaDB APIs Swagger Page at https://vocadb.net/swagger/ui/index
-    # but currently we only support NicoNicoDouga, Youtube and Bilibili
-    pv-preference: NicoNicoDouga, Youtube, Bilibili
+    # but currently we only support NicoNicoDouga, Youtube, Bilibili and SoundCloud
+    pv-preference: NicoNicoDouga, SoundCloud, Youtube, Bilibili
     # maximum retry before calling it a failure
     # this does not include the first try. For example, 2 means a maximum of 3 tries can be performed
     max-retry-count: 2
@@ -47,6 +47,8 @@ config: # configuration
     Youtube: 
     # currently only support youtube-dl
     Bilibili:
+    # currently only support youtube-dl
+    SoundCloud:
 
   # which field is required or optional depends on if the pv service is listed in config.preference.pv-preference field also if the downloader is enabled in the config.enablement field
   downloader:
@@ -78,6 +80,12 @@ config: # configuration
 
     # same way of configuring NicoNicoDouga
     Bilibili:
+      youtube-dl:
+        launch-cmd:
+        external-args:
+
+    # same way of configuring NicoNicoDouga
+    SoundCloud:
       youtube-dl:
         launch-cmd:
         external-args:

--- a/vvd-downloader/src/test/kotlin/mikufan/cx/vvd/downloader/component/downloader/base/BaseYtDlDownloaderTest.kt
+++ b/vvd-downloader/src/test/kotlin/mikufan/cx/vvd/downloader/component/downloader/base/BaseYtDlDownloaderTest.kt
@@ -6,11 +6,11 @@ import mikufan.cx.vocadbapiclient.model.SongForApiContract
 import mikufan.cx.vvd.common.label.VSongLabel
 import mikufan.cx.vvd.downloader.component.downloader.implementation.BilibiliYtDlDownloader
 import mikufan.cx.vvd.downloader.component.downloader.implementation.NicoNicoYtDlDownloader
+import mikufan.cx.vvd.downloader.component.downloader.implementation.SoundCloudYtDlDownloader
 import mikufan.cx.vvd.downloader.component.downloader.implementation.YoutubeYtDlDownloader
 import mikufan.cx.vvd.downloader.config.IOConfig
 import mikufan.cx.vvd.downloader.model.Parameters
 import mikufan.cx.vvd.downloader.model.VSongTask
-import mikufan.cx.vvd.downloader.util.SpringBootDirtyTestWithTestProfile
 import mikufan.cx.vvd.downloader.util.SpringBootTestWithTestProfile
 import mikufan.cx.vvd.downloader.util.SpringShouldSpec
 import mikufan.cx.vvd.downloader.util.loadResourceAsString
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Disabled
     "config.downloader.NicoNicoDouga.youtube-dl.launch-cmd=yt-dlp",
     "config.downloader.Youtube.youtube-dl.launch-cmd=yt-dlp",
     "config.downloader.Bilibili.youtube-dl.launch-cmd=yt-dlp",
+    "config.downloader.sound-cloud.youtube-dl.launch-cmd=yt-dlp",
   ]
 )
 @Disabled("do not download PVs for every commit in CI")
@@ -28,6 +29,7 @@ class BaseYtDlDownloaderTest(
   private val nicoNicoYtDlDownloader: NicoNicoYtDlDownloader,
   private val youtubeYtDlDownloader: YoutubeYtDlDownloader,
   private val bilibiliYtDlDownloader: BilibiliYtDlDownloader,
+  private val soundCloudYtDlDownloader: SoundCloudYtDlDownloader,
   private val objectMapper: ObjectMapper,
   ioConfig: IOConfig,
 ) : SpringShouldSpec({
@@ -55,6 +57,10 @@ class BaseYtDlDownloaderTest(
 
     should("successfully download video and thumbnail from bilibili") {
       testDownload("2021年V家新曲-label/【初音ミク, 神威がくぽ】侵蝕性⇆恋愛症候群【天钦, 动点P】[335778]-songInfo.json", 0, bilibiliYtDlDownloader)
+    }
+
+    should("successfully download video and thumbnail from soundcloud") {
+      testDownload("2021年V家新曲-label/【初音ミク】WANCO!!【Twinfield】[336290]-songInfo.json", 2, soundCloudYtDlDownloader)
     }
   }
 })

--- a/vvd-downloader/src/test/resources/application-test.yml
+++ b/vvd-downloader/src/test/resources/application-test.yml
@@ -11,6 +11,7 @@ config: # configuration
     NicoNicoDouga: youtube-dl
     Youtube: youtube-dl
     Bilibili: youtube-dl
+    SoundCloud: youtube-dl
 
 
   downloader:
@@ -31,6 +32,12 @@ config: # configuration
     Bilibili:
       youtube-dl:
         launch-cmd: python, ./youtube-dl/__main__.py # can be separated by comma as well
+        external-args:
+          - -v
+
+    SoundCloud:
+      youtube-dl:
+        launch-cmd: yt-dlp
         external-args:
           - -v
   environment:


### PR DESCRIPTION
SoundCloud was incorporated as a supported platform for video downloads. Changes include adding SoundCloud to the list of supported platforms in the PvServiceValidation file. New configuration files for SoundCloud were added to enable this feature, including SoundCloudConfigs.kt, SoundCloudConditions.kt, and SoundCloudConstants.kt. Lastly, the application.yml file was updated to reflect these changes and allow for SoundCloud's configuration.